### PR TITLE
Fix for deleting an item from non-unique index

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.30",
+  "version": "0.6.31",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -1375,6 +1375,54 @@ describe("ObjectStoreProvider", function () {
             .catch((e) => done(e));
         });
 
+        it("Putting the same secondary non-unique key should overwrite", (done) => {
+          let objToPut = { id: "a", val: "b" };
+          openProvider(
+            provName,
+            {
+              version: 1,
+              stores: [
+                {
+                  name: "test",
+                  primaryKeyPath: "id",
+                  indexes: [
+                    {
+                      name: "index",
+                      keyPath: "val",
+                      unique: false,
+                      includeDataInIndex: true,
+                    },
+                  ],
+                },
+              ],
+            },
+            true
+          )
+            .then((prov) =>
+              prov
+                .put("test", objToPut)
+                // add another item with the same index value
+                .then(() => (objToPut = { id: "c", val: "b" }))
+                .then(() => prov.put("test", objToPut))
+                .then(() => prov.get("test", "a"))
+                .then((retVal) => assert.equal((retVal as TestObj).val, "b"))
+                .then(() => prov.getOnly("test", "index", "b"))
+                // non-unique index should have two items: a and c primary keys
+                .then((retVal) => assert.equal((retVal as TestObj[]).length, 2))
+                // add another item with the same pk as the first one, 
+                // it should overwrite the "a" item, but also keep the "c" item in the index
+                .then(() => (objToPut = { id: "a", val: "b" }))
+                .then(() => prov.put("test", objToPut))
+                .then(() => prov.getOnly("test", "index", "b"))
+                // non-unique index should still have two items
+                .then((retVal) => assert.equal((retVal as TestObj[]).length, 2))
+                .then(() => prov.close())
+                .catch((e) => prov.close().then(() => Promise.reject(e)))
+                .then(() => done())
+            )
+            .catch((e) => done(e));
+        });
+
         it("Empty gets/puts", (done) => {
           openProvider(
             provName,

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -1409,7 +1409,7 @@ describe("ObjectStoreProvider", function () {
                 .then(() => prov.getOnly("test", "index", "b"))
                 // non-unique index should have two items: a and c primary keys
                 .then((retVal) => assert.equal((retVal as TestObj[]).length, 2))
-                // add another item with the same pk as the first one, 
+                // add another item with the same pk as the first one,
                 // it should overwrite the "a" item, but also keep the "c" item in the index
                 .then(() => (objToPut = { id: "a", val: "b" }))
                 .then(() => prov.put("test", objToPut))


### PR DESCRIPTION
When an item is removed from the store, non-unique index it is part of, will be reset to undefined:
![image](https://user-images.githubusercontent.com/12691471/127923193-d1f5bdf9-6015-4539-8901-24f85483f16a.png)

`ind.remove` will remove all values from the index, even if there are multiple items in that index (in case of non-unique index).

In this fix we're splitting remove operation in two steps for non-unique indices:
* Find the index value (array of items with the same index)
* Using primary key, locate and remove the item from the array

There are possibly some performance implications to doing `array.filter` to remove the item, but could not come up with a better way of removing item without iterating over all array items -- yes, we can stop comparing pks after the first match, but we still need to go over the rest of items to finish copying the array.