### PR TITLE
Replace rbtree with b+tree

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "@collectable/core": "^5.0.1",
     "@collectable/red-black-tree": "^5.0.1",
     "lodash": "^4.17.21",
-    "regexp-i18n": "^1.3.2"
+    "regexp-i18n": "^1.3.2",
+    "sorted-btree": "^1.5.0"
   },
   "sideEffects": [
     "./src/Promise.ts"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.30",
+  "version": "0.6.32",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -542,6 +542,12 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
     return Promise.resolve(compact(flatten(values)));
   }
 
+  /**
+   * Removes item from index. For non-unique indices, a pair of index value and a primary key is required.
+   * @param key a string, if it's a unique index, a pair of key value and a primary key, if it's a non-unique index
+   * @param skipTransactionOnCreation
+   * @returns
+   */
   public remove(
     key: string | { primaryKey: string; idxKey: string },
     skipTransactionOnCreation?: boolean
@@ -566,10 +572,10 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
         return idxItemPrimaryKeyVal !== key.primaryKey;
       });
 
-      // removed all items? remove the index tree node
+      // if we removed all items, remove the index tree node.
       // otherwise, update the index value with the new array
       // sans the primary key item
-      if (idxItemsWithoutItem?.length === 0) {
+      if (idxItemsWithoutItem.length === 0) {
         this._indexTree.delete(key.idxKey);
       } else {
         this._indexTree.set(key.idxKey, idxItemsWithoutItem);
@@ -603,6 +609,7 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
         continue;
       }
 
+      // a hack to account for offset that b+tree library lacks
       if (skip > 0) {
         skip--;
         continue;

--- a/src/ordered-map/BTreeOrderedMap.ts
+++ b/src/ordered-map/BTreeOrderedMap.ts
@@ -1,0 +1,53 @@
+import BTree from "sorted-btree";
+import { IKeyValuePair } from "./IKeyValuePair";
+import { IOrderedMap } from "./IOrderedMap";
+
+export class BTreeOrderedMap<K = any, V = any> implements IOrderedMap<K, V> {
+  private readonly _tree: BTree;
+
+  constructor() {
+    this._tree = new BTree();
+  }
+
+  public get size(): number {
+    return this._tree.size;
+  }
+
+  public get(key: K, defaultValue?: V): V | undefined {
+    return this._tree.get(key, defaultValue);
+  }
+
+  public set(key: K, value: V, overwrite?: boolean): void {
+    this._tree.set(key, value, overwrite);
+  }
+
+  public has(key: K): boolean {
+    return this._tree.has(key);
+  }
+
+  public delete(key: K): void {
+    this._tree.delete(key);
+  }
+
+  public *entries(lowestKey?: K): IterableIterator<IKeyValuePair<K, V>> {
+    for (const value of this._tree.entries(lowestKey)) {
+      yield this.toKeyValue(value);
+    }
+  }
+
+  public *entriesReversed(
+    highestKey?: K
+  ): IterableIterator<IKeyValuePair<K, V>> {
+    for (const value of this._tree.entriesReversed(highestKey)) {
+      yield this.toKeyValue(value);
+    }
+  }
+
+  private toKeyValue(kvpAsArray?: [K, V]): IKeyValuePair<K, V> {
+    if (kvpAsArray && kvpAsArray.length && kvpAsArray.length === 2) {
+      return { key: kvpAsArray[0], value: kvpAsArray[1] };
+    }
+
+    return { key: undefined, value: undefined };
+  }
+}

--- a/src/ordered-map/IKeyValuePair.ts
+++ b/src/ordered-map/IKeyValuePair.ts
@@ -1,0 +1,4 @@
+export interface IKeyValuePair<K, V> {
+  key?: K;
+  value?: V;
+}

--- a/src/ordered-map/IOrderedMap.ts
+++ b/src/ordered-map/IOrderedMap.ts
@@ -18,7 +18,6 @@ export interface IOrderedMap<K, V> {
    * @param overwrite Whether to overwrite an existing key-value pair
    *        (default: true). If this is false and there is an existing
    *        key-value pair then this method has no effect.
-   * @returns true if a new key-value pair was added.
    * @description Computational complexity: O(log size)
    * Note: when overwriting a previous entry, the key is updated
    * as well as the value. This has no effect unless the new key
@@ -36,7 +35,6 @@ export interface IOrderedMap<K, V> {
   /**
    * Removes a single key-value pair from the B+ tree.
    * @param key Key to find
-   * @returns true if a pair was found and removed, false otherwise.
    * @description Computational complexity: O(log size)
    */
   delete(key: K): void;
@@ -45,25 +43,16 @@ export interface IOrderedMap<K, V> {
    *  @param lowestKey First key to be iterated, or undefined to start at
    *         minKey(). If the specified key doesn't exist then iteration
    *         starts at the next higher key (according to the comparator).
-   *  @param reusedArray Optional array used repeatedly to store key-value
-   *         pairs, to avoid creating a new array on every iteration.
    */
   entries(
-    lowestKey?: K,
-    reusedArray?: (K | V)[]
+    lowestKey?: K
   ): IterableIterator<IKeyValuePair<K, V>>;
   /** Returns an iterator that provides items in reversed order.
    *  @param highestKey Key at which to start iterating, or undefined to
    *         start at maxKey(). If the specified key doesn't exist then iteration
    *         starts at the next lower key (according to the comparator).
-   *  @param reusedArray Optional array used repeatedly to store key-value
-   *         pairs, to avoid creating a new array on every iteration.
-   *  @param skipHighest Iff this flag is true and the highestKey exists in the
-   *         collection, the pair matching highestKey is skipped, not iterated.
    */
   entriesReversed(
-    highestKey?: K,
-    reusedArray?: (K | V)[],
-    skipHighest?: boolean
+    highestKey?: K
   ): IterableIterator<IKeyValuePair<K, V>>;
 }

--- a/src/ordered-map/IOrderedMap.ts
+++ b/src/ordered-map/IOrderedMap.ts
@@ -1,0 +1,69 @@
+import { IKeyValuePair } from "./IKeyValuePair";
+
+export interface IOrderedMap<K, V> {
+  /** Gets the number of key-value pairs in the tree. */
+  get size(): number;
+  /**
+   * Finds a pair in the tree and returns the associated value.
+   * @param defaultValue a value to return if the key was not found.
+   * @returns the value, or defaultValue if the key was not found.
+   * @description Computational complexity: O(log size)
+   */
+  get(key: K, defaultValue?: V): V | undefined;
+  /**
+   * Adds or overwrites a key-value pair in the B+ tree.
+   * @param key the key is used to determine the sort order of
+   *        data in the tree.
+   * @param value data to associate with the key (optional)
+   * @param overwrite Whether to overwrite an existing key-value pair
+   *        (default: true). If this is false and there is an existing
+   *        key-value pair then this method has no effect.
+   * @returns true if a new key-value pair was added.
+   * @description Computational complexity: O(log size)
+   * Note: when overwriting a previous entry, the key is updated
+   * as well as the value. This has no effect unless the new key
+   * has data that does not affect its sort order.
+   */
+  set(key: K, value: V, overwrite?: boolean): void;
+  /**
+   * Returns true if the key exists in the B+ tree, false if not.
+   * Use get() for best performance; use has() if you need to
+   * distinguish between "undefined value" and "key not present".
+   * @param key Key to detect
+   * @description Computational complexity: O(log size)
+   */
+  has(key: K): boolean;
+  /**
+   * Removes a single key-value pair from the B+ tree.
+   * @param key Key to find
+   * @returns true if a pair was found and removed, false otherwise.
+   * @description Computational complexity: O(log size)
+   */
+  delete(key: K): void;
+  /** Returns an iterator that provides items in order (ascending order if
+   *  the collection's comparator uses ascending order, as is the default.)
+   *  @param lowestKey First key to be iterated, or undefined to start at
+   *         minKey(). If the specified key doesn't exist then iteration
+   *         starts at the next higher key (according to the comparator).
+   *  @param reusedArray Optional array used repeatedly to store key-value
+   *         pairs, to avoid creating a new array on every iteration.
+   */
+  entries(
+    lowestKey?: K,
+    reusedArray?: (K | V)[]
+  ): IterableIterator<IKeyValuePair<K, V>>;
+  /** Returns an iterator that provides items in reversed order.
+   *  @param highestKey Key at which to start iterating, or undefined to
+   *         start at maxKey(). If the specified key doesn't exist then iteration
+   *         starts at the next lower key (according to the comparator).
+   *  @param reusedArray Optional array used repeatedly to store key-value
+   *         pairs, to avoid creating a new array on every iteration.
+   *  @param skipHighest Iff this flag is true and the highestKey exists in the
+   *         collection, the pair matching highestKey is skipped, not iterated.
+   */
+  entriesReversed(
+    highestKey?: K,
+    reusedArray?: (K | V)[],
+    skipHighest?: boolean
+  ): IterableIterator<IKeyValuePair<K, V>>;
+}

--- a/src/ordered-map/IOrderedMap.ts
+++ b/src/ordered-map/IOrderedMap.ts
@@ -44,15 +44,11 @@ export interface IOrderedMap<K, V> {
    *         minKey(). If the specified key doesn't exist then iteration
    *         starts at the next higher key (according to the comparator).
    */
-  entries(
-    lowestKey?: K
-  ): IterableIterator<IKeyValuePair<K, V>>;
+  entries(lowestKey?: K): IterableIterator<IKeyValuePair<K, V>>;
   /** Returns an iterator that provides items in reversed order.
    *  @param highestKey Key at which to start iterating, or undefined to
    *         start at maxKey(). If the specified key doesn't exist then iteration
    *         starts at the next lower key (according to the comparator).
    */
-  entriesReversed(
-    highestKey?: K
-  ): IterableIterator<IKeyValuePair<K, V>>;
+  entriesReversed(highestKey?: K): IterableIterator<IKeyValuePair<K, V>>;
 }

--- a/src/ordered-map/OrderedMapType.ts
+++ b/src/ordered-map/OrderedMapType.ts
@@ -1,0 +1,1 @@
+export type OrderedMapType = "b+tree" | "red-black-tree";

--- a/src/ordered-map/RBTreeOrderedMap.ts
+++ b/src/ordered-map/RBTreeOrderedMap.ts
@@ -1,0 +1,52 @@
+import {
+  empty,
+  get,
+  has,
+  iterateFromFirst,
+  iterateFromLast,
+  RedBlackTreeStructure,
+  remove,
+  set,
+} from "@collectable/red-black-tree";
+import { IKeyValuePair } from "./IKeyValuePair";
+import { IOrderedMap } from "./IOrderedMap";
+
+export class RBTreeOrderedMap<K = any, V = any> implements IOrderedMap<K, V> {
+  private _tree: RedBlackTreeStructure<K, V>;
+
+  constructor() {
+    this._tree = empty<K, V>(defaultComparator, true);
+  }
+
+  public get size(): number {
+    return this._tree._size;
+  }
+
+  public get(key: K, defaultValue?: V): V | undefined {
+    return get(key, this._tree) || defaultValue;
+  }
+
+  public set(key: K, value: V, _overwrite?: boolean): void {
+    set(key, value, this._tree);
+  }
+
+  public has(key: K): boolean {
+    return has(key, this._tree);
+  }
+
+  public delete(key: K): void {
+    remove(key, this._tree);
+  }
+
+  public entries(_lowestKey?: K): IterableIterator<IKeyValuePair<K, V>> {
+    return iterateFromFirst(this._tree);
+  }
+
+  public entriesReversed(
+    _highestKey?: K
+  ): IterableIterator<IKeyValuePair<K, V>> {
+    return iterateFromLast(this._tree);
+  }
+}
+
+const defaultComparator = (a: any, b: any) => (a < b ? -1 : a > b ? 1 : 0);

--- a/src/ordered-map/index.ts
+++ b/src/ordered-map/index.ts
@@ -1,0 +1,16 @@
+import { BTreeOrderedMap } from "./BTreeOrderedMap";
+import { OrderedMapType } from "./OrderedMapType";
+import { RBTreeOrderedMap } from "./RBTreeOrderedMap";
+
+export { IOrderedMap } from "./IOrderedMap";
+export { OrderedMapType };
+
+export const createOrderedMap = <K, V>(mapType?: OrderedMapType) => {
+  switch (mapType) {
+    case "b+tree":
+      return new BTreeOrderedMap<K, V>();
+    case "red-black-tree":
+    default:
+      return new RBTreeOrderedMap();
+  }
+};

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -1375,6 +1375,54 @@ describe("ObjectStoreProvider", function () {
             .catch((e) => done(e));
         });
 
+        it("Putting the same secondary non-unique key should overwrite", (done) => {
+          let objToPut = { id: "a", val: "b" };
+          openProvider(
+            provName,
+            {
+              version: 1,
+              stores: [
+                {
+                  name: "test",
+                  primaryKeyPath: "id",
+                  indexes: [
+                    {
+                      name: "index",
+                      keyPath: "val",
+                      unique: false,
+                      includeDataInIndex: true,
+                    },
+                  ],
+                },
+              ],
+            },
+            true
+          )
+            .then((prov) =>
+              prov
+                .put("test", objToPut)
+                // add another item with the same index value
+                .then(() => (objToPut = { id: "c", val: "b" }))
+                .then(() => prov.put("test", objToPut))
+                .then(() => prov.get("test", "a"))
+                .then((retVal) => assert.equal((retVal as TestObj).val, "b"))
+                .then(() => prov.getOnly("test", "index", "b"))
+                // non-unique index should have two items: a and c primary keys
+                .then((retVal) => assert.equal((retVal as TestObj[]).length, 2))
+                // add another item with the same pk as the first one, 
+                // it should overwrite the "a" item, but also keep the "c" item in the index
+                .then(() => (objToPut = { id: "a", val: "b" }))
+                .then(() => prov.put("test", objToPut))
+                .then(() => prov.getOnly("test", "index", "b"))
+                // non-unique index should still have two items
+                .then((retVal) => assert.equal((retVal as TestObj[]).length, 2))
+                .then(() => prov.close())
+                .catch((e) => prov.close().then(() => Promise.reject(e)))
+                .then(() => done())
+            )
+            .catch((e) => done(e));
+        });
+
         it("Empty gets/puts", (done) => {
           openProvider(
             provName,

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -1409,7 +1409,7 @@ describe("ObjectStoreProvider", function () {
                 .then(() => prov.getOnly("test", "index", "b"))
                 // non-unique index should have two items: a and c primary keys
                 .then((retVal) => assert.equal((retVal as TestObj[]).length, 2))
-                // add another item with the same pk as the first one, 
+                // add another item with the same pk as the first one,
                 // it should overwrite the "a" item, but also keep the "c" item in the index
                 .then(() => (objToPut = { id: "a", val: "b" }))
                 .then(() => prov.put("test", objToPut))

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -28,8 +28,10 @@ function openProvider(
   handleOnClose?: OnCloseHandler
 ) {
   let provider: DbProvider;
-  if (providerName === "memory") {
-    provider = new InMemoryProvider();
+  if (providerName === "memory-rbtree") {
+    provider = new InMemoryProvider("red-black-tree");
+  } else if (providerName === "memory-btree") {
+    provider = new InMemoryProvider("b+tree");
   } else if (providerName === "indexeddb") {
     provider = new IndexedDbProvider();
   } else if (providerName === "indexeddbfakekeys") {
@@ -55,7 +57,7 @@ describe("ObjectStoreProvider", function () {
   this.timeout(5 * 60 * 1000);
 
   let provsToTest: string[];
-  provsToTest = ["memory"];
+  provsToTest = ["memory-rbtree", "memory-btree"];
   provsToTest.push("indexeddb", "indexeddbfakekeys", "indexeddbonclose");
 
   it("Number/value/type sorting", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3076,6 +3076,11 @@ socket.io@^3.1.0:
     socket.io-adapter "~2.1.0"
     socket.io-parser "~4.0.3"
 
+sorted-btree@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/sorted-btree/-/sorted-btree-1.5.0.tgz#57b621c10e124c34122c6c156becda0e4731b19f"
+  integrity sha512-1KzY80r3VpwGLGN/9oWjReUml3czxKfLz4iMV8Ro9KAHCg9xt0HwTkcb20JR+sHCiR5WUJ6uMAbe/HB3gy1qYA==
+
 source-list-map@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"


### PR DESCRIPTION
This contains two changes.
1. Adding an alternative tree library (ordered-btree) to use for indexing inside of in-memory provider. We noticed that red-black-tree has a bug in it that causes it to go into an infinite loop when the tree is being rebalanced. This change makes it possible to choose between the two libraries when database is created.
2. A small fix for non-unique indices. When an item is removed from the store, non-unique index it is part of, will be reset to undefined:
![image](https://user-images.githubusercontent.com/12691471/127923193-d1f5bdf9-6015-4539-8901-24f85483f16a.png)

`ind.remove` will remove all values from the index, even if there are multiple items in that index (in case of non-unique index).

In this fix we're splitting remove operation in two steps for non-unique indices:
* Find the index value (array of items with the same index)
* Using primary key, locate and remove the item from the array

There are possibly some performance implications to doing `array.filter` to remove the item, but could not come up with a better way of removing item without iterating over all array items -- yes, we can stop comparing pks after the first match, but we still need to go over the rest of items to finish copying the array.