### PR TITLE
Lock RB Tree Version to limit variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@collectable/core": "^5.0.1",
-    "@collectable/red-black-tree": "^5.0.1",
+    "@collectable/red-black-tree": "5.0.1",
     "lodash": "^4.17.21",
     "regexp-i18n": "^1.3.2",
     "sorted-btree": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.33",
+  "version": "0.6.34",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,7 +31,7 @@
     "@frptools/corelib" "^1.1.0"
     "@frptools/structural" "^1.0.0"
 
-"@collectable/red-black-tree@^5.0.1":
+"@collectable/red-black-tree@5.0.1":
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/@collectable/red-black-tree/-/red-black-tree-5.0.1.tgz#984659265daf753029b57c2ca213bcde792a8664"
   integrity sha1-mEZZJl2vdTAptXwsohO83nkqhmQ=


### PR DESCRIPTION
RB Tree version had a carrot in front of it which means that it can update to any major version. Instead, we want to limit the amount of variables for the in-memory provider library while we're making the BTree changes so locking it to the 5.0.1 version.