### PR TITLE
upgrade red-black-tree dependency to 5.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.34",
+  "version": "0.6.35",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "@collectable/core": "^5.0.1",
-    "@collectable/red-black-tree": "5.0.1",
+    "@collectable/red-black-tree": "^5.1.1",
     "lodash": "^4.17.21",
     "regexp-i18n": "^1.3.2",
     "sorted-btree": "^1.5.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -31,10 +31,10 @@
     "@frptools/corelib" "^1.1.0"
     "@frptools/structural" "^1.0.0"
 
-"@collectable/red-black-tree@5.0.1":
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/@collectable/red-black-tree/-/red-black-tree-5.0.1.tgz#984659265daf753029b57c2ca213bcde792a8664"
-  integrity sha1-mEZZJl2vdTAptXwsohO83nkqhmQ=
+"@collectable/red-black-tree@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@collectable/red-black-tree/-/red-black-tree-5.1.1.tgz#9db9c1f13dcea45ef032334801bd431ed6a00855"
+  integrity sha512-xAjh0RKBIcXachRTMCySskheqKfRFn+zuW3SUCqeg4roj00w/3kPeEKor6fHHrcIfk/QAiyVAL8oMkpItr8nzQ==
   dependencies:
     "@collectable/core" "^5.0.1"
 


### PR DESCRIPTION
We previously pinned to 5.0.1 to avoid issues, upgrading now.