### PR TITLE
Plumb limit to full text search function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.35",
+  "version": "0.6.36",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/ObjectStoreProvider.ts
+++ b/src/ObjectStoreProvider.ts
@@ -401,7 +401,7 @@ export abstract class DbProvider {
   ): Promise<ItemType[]> {
     return this._getStoreIndexTransaction(storeName, false, indexName).then(
       (index) => {
-        return index.fullTextSearch(searchPhrase, resolution);
+        return index.fullTextSearch(searchPhrase, resolution, _limit);
       }
     );
   }

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -4519,7 +4519,7 @@ describe("ObjectStoreProvider", function () {
         });
       }
 
-      it("Full Text Index", (done) => {
+      it("Full Text Index - Happy path", (done) => {
         openProvider(
           provName,
           {
@@ -4878,6 +4878,44 @@ describe("ObjectStoreProvider", function () {
             () => done(),
             (err) => done(err)
           );
+      });
+
+      it("Full Text Index - Returns only the limit passed", async () => {
+        return openProvider(
+          provName,
+          {
+            version: 2,
+            stores: [
+              {
+                name: "test",
+                primaryKeyPath: "id",
+                indexes: [
+                  {
+                    name: "i",
+                    keyPath: "txt",
+                    fullText: true,
+                    unique: false,
+                  },
+                ],
+              },
+            ],
+          },
+          true
+        ).then((prov) => {
+          const itemsToPut = [];
+          for (var i = 0; i < 100; i++) {
+            itemsToPut.push({ id: `a${i}`, txt: `aaaaaa${i}` });
+          }
+
+          prov.put("test", itemsToPut).then(() => {
+            prov
+              .fullTextSearch("test", "i", "a", FullTextTermResolution.Or, 10)
+              .then((results) => {
+                assert.equal(results.length, 10);
+                prov.close();
+              });
+          });
+        });
       });
     });
   });


### PR DESCRIPTION
When doing a full text search we ignore the limit param. Pass it through and add UTs to make sure it works.