### PR TITLE
InMemoryStore will create commitedStoreData only when provider supportsRollback

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.38",
+  "version": "0.6.39",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -67,13 +67,15 @@ export class InMemoryProvider extends DbProvider {
 
   private _lockHelper: TransactionLockHelper | undefined;
   private readonly _mapType?: OrderedMapType;
+  private readonly _supportsRollback?: boolean;
 
   constructor(
     mapType?: OrderedMapType,
-    public supportsRollback: boolean = false
+    supportsRollback = false
   ) {
     super();
     this._mapType = mapType;
+    this._supportsRollback = supportsRollback;
   }
 
   open(
@@ -113,7 +115,7 @@ export class InMemoryProvider extends DbProvider {
           this._lockHelper!!!,
           token,
           writeNeeded,
-          this.supportsRollback
+          this._supportsRollback!
         )
     );
   }
@@ -168,7 +170,7 @@ class InMemoryTransaction implements DbTransaction {
   abort(): void {
     if (!this._supportsRollback) {
       throw new Error(
-        "Unable to abort since provider doesn't support rollback"
+        "Unable to abort transaction since provider doesn't support rollback"
       );
     }
     this._stores.forEach((store) => {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -198,7 +198,7 @@ class InMemoryTransaction implements DbTransaction {
   }
 }
 
-class InMemoryStore implements DbStore {
+export class InMemoryStore implements DbStore {
   private _committedStoreData?: Map<string, ItemType>;
   private _mergedData: Map<string, ItemType>;
   private _storeSchema: StoreSchema;

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -204,7 +204,11 @@ class InMemoryStore implements DbStore {
   private _storeSchema: StoreSchema;
   private _indices: Map<string, InMemoryIndex>;
   private _mapType?: OrderedMapType;
-  constructor(private _trans: InMemoryTransaction, storeInfo: StoreData, private _writeNeeded: boolean) {
+  constructor(
+    private _trans: InMemoryTransaction,
+    storeInfo: StoreData,
+    private _writeNeeded: boolean
+  ) {
     this._storeSchema = storeInfo.schema;
     if (this._writeNeeded) this._committedStoreData = new Map(storeInfo.data);
     this._indices = storeInfo.indices;

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -69,10 +69,7 @@ export class InMemoryProvider extends DbProvider {
   private readonly _mapType?: OrderedMapType;
   private readonly _supportsRollback?: boolean;
 
-  constructor(
-    mapType?: OrderedMapType,
-    supportsRollback = false
-  ) {
+  constructor(mapType?: OrderedMapType, supportsRollback = false) {
     super();
     this._mapType = mapType;
     this._supportsRollback = supportsRollback;

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -216,7 +216,7 @@ class InMemoryTransaction implements DbTransaction {
   }
 }
 
-export class InMemoryStore implements DbStore {
+class InMemoryStore implements DbStore {
   private _committedStoreData?: Map<string, ItemType>;
   private _mergedData: Map<string, ItemType>;
   private _storeSchema: StoreSchema;

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -4986,7 +4986,7 @@ describe("ObjectStoreProvider", function () {
             for (var i = 0; i < 10; i++) {
               itemsToPut.push({ id: `a${i}`, txt: `aaaaaa${i}` });
             }
-            assert.equal((<InMemoryProvider>prov).supportsRollback, false);
+            assert.equal((<InMemoryProvider>prov)["_supportsRollback"], false);
             prov.put("test", itemsToPut).then(() => {
               prov.openTransaction(["test"], false).then((transaction) => {
                 const store = <InMemoryStore>transaction.getStore("test");
@@ -5017,7 +5017,7 @@ describe("ObjectStoreProvider", function () {
             for (var i = 0; i < 10; i++) {
               itemsToPut.push({ id: `a${i}`, txt: `aaaaaa${i}` });
             }
-            assert.equal((<InMemoryProvider>prov).supportsRollback, true);
+            assert.equal((<InMemoryProvider>prov)["_supportsRollback"], true);
             prov.put("test", itemsToPut).then(() => {
               prov.openTransaction(["test"], true).then((transaction) => {
                 const store = <InMemoryStore>transaction.getStore("test");

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -14,7 +14,7 @@ import {
   OnCloseHandler,
 } from "../ObjectStoreProvider";
 
-import { InMemoryProvider, InMemoryStore } from "../InMemoryProvider";
+import { InMemoryProvider } from "../InMemoryProvider";
 import { IndexedDbProvider } from "../IndexedDbProvider";
 
 import { serializeValueToOrderableString } from "../ObjectStoreProviderUtils";
@@ -4989,7 +4989,7 @@ describe("ObjectStoreProvider", function () {
             assert.equal((<InMemoryProvider>prov)["_supportsRollback"], false);
             prov.put("test", itemsToPut).then(() => {
               prov.openTransaction(["test"], false).then((transaction) => {
-                const store = <InMemoryStore>transaction.getStore("test");
+                const store = <any>transaction.getStore("test"); // InMemoryStore
                 assert.equal(store["_supportsRollback"], false);
                 assert.equal(store["_committedStoreData"], undefined);
                 prov.close();
@@ -5020,7 +5020,7 @@ describe("ObjectStoreProvider", function () {
             assert.equal((<InMemoryProvider>prov)["_supportsRollback"], true);
             prov.put("test", itemsToPut).then(() => {
               prov.openTransaction(["test"], true).then((transaction) => {
-                const store = <InMemoryStore>transaction.getStore("test");
+                const store = <any>transaction.getStore("test"); // InMemoryStore
                 assert.equal(store["_supportsRollback"], true);
                 assert.equal(
                   Array.from(store["_committedStoreData"]?.values() || [])


### PR DESCRIPTION
When opening a transaction on InMemoryProvider, we pass information whether it is read-only or write operation. But, this information wasn't passed down to InMemoryStore and due to which it created a new Map with store data for all read-only operation (thereby increasing memory usage).

- This PR will ensure that the data Map is created only for write operation, so that it can be used for rollback when a transaction is aborted.
- InMemoryProvider will have `supportsRollback` property (default is false) which needs to be set before trying to `abort` a transaction.
- Bumped up the `version` in package.json
- Added test for InMemoryProvider