### PR TITLE
Avoid clearing object stores when db doesn't exist yet

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.39",
+  "version": "0.6.40",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {


### PR DESCRIPTION
During IndexedDb.open, we'll execute onupgradeneeded callback function. This gets `oldVersion` property and delete existing object stores when we have old version than what we are intending to read/write to. This property returns 0 when db doesn't exist and we can avoid clearing object stores in this case.
