### PR TITLE
Optional logger

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,6 +23,7 @@ export {
   DBClosure,
   OnCloseHandler,
   openListOfProviders,
+  IObjectStoreProviderLogger,
 } from "./src/ObjectStoreProvider";
 export {
   isIE,
@@ -50,4 +51,3 @@ export {
   TransactionToken,
 } from "./src/TransactionLockHelper";
 export type { OrderedMapType } from "./src/ordered-map";
-export { Logger } from "./src/ObjectStoreProviderUtils";

--- a/index.ts
+++ b/index.ts
@@ -50,4 +50,4 @@ export {
   TransactionToken,
 } from "./src/TransactionLockHelper";
 export type { OrderedMapType } from "./src/ordered-map";
-export type { Logger } from "./src/ObjectStoreProviderUtils";
+export { Logger } from "./src/ObjectStoreProviderUtils";

--- a/index.ts
+++ b/index.ts
@@ -50,3 +50,4 @@ export {
   TransactionToken,
 } from "./src/TransactionLockHelper";
 export type { OrderedMapType } from "./src/ordered-map";
+export type { Logger } from "./src/ObjectStoreProviderUtils";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.41",
+  "version": "0.6.42",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -76,7 +76,11 @@ export class InMemoryProvider extends DbProvider {
   private readonly _supportsRollback?: boolean;
   private logger: Logger | undefined;
 
-  constructor(mapType?: OrderedMapType, supportsRollback = false, logger?: Logger) {
+  constructor(
+    mapType?: OrderedMapType,
+    supportsRollback = false,
+    logger?: Logger
+  ) {
     super();
     this._mapType = mapType;
     this._supportsRollback = supportsRollback;
@@ -177,7 +181,9 @@ class InMemoryTransaction implements DbTransaction {
 
   abort(): void {
     if (!this._supportsRollback) {
-      this.logger.error("Unable to abort transaction since provider doesn't support rollback");
+      this.logger.error(
+        "Unable to abort transaction since provider doesn't support rollback"
+      );
       throw new Error(
         "Unable to abort transaction since provider doesn't support rollback"
       );

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -45,6 +45,7 @@ import {
   getSerializedKeyForKeypath,
   getValueForSingleKeypath,
   MAX_COUNT,
+  Logger,
   trimArray,
 } from "./ObjectStoreProviderUtils";
 import {
@@ -60,12 +61,6 @@ export interface StoreData {
   schema: StoreSchema;
   mapType?: OrderedMapType;
 }
-
-type Logger = {
-  log(message?: any, ...optionalParams: any[]): void;
-  warn(message?: any, ...optionalParams: any[]): void;
-  error(message?: any, ...optionalParams: any[]): void;
-};
 
 // Very simple in-memory dbprovider for handling IE inprivate windows (and unit tests, maybe?)
 export class InMemoryProvider extends DbProvider {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -74,7 +74,7 @@ export class InMemoryProvider extends DbProvider {
   private _lockHelper: TransactionLockHelper | undefined;
   private readonly _mapType?: OrderedMapType;
   private readonly _supportsRollback?: boolean;
-  private logger: Logger | undefined;
+  private logger: Logger;
 
   constructor(
     mapType?: OrderedMapType,
@@ -152,7 +152,7 @@ class InMemoryTransaction implements DbTransaction {
     private _transToken: TransactionToken,
     private _writeNeeded: boolean,
     private _supportsRollback: boolean,
-    private logger: Logger | undefined
+    private logger: Logger
   ) {
     // Close the transaction on the next tick.  By definition, anything is completed synchronously here, so after an event tick
     // goes by, there can't have been anything pending.
@@ -181,7 +181,7 @@ class InMemoryTransaction implements DbTransaction {
 
   abort(): void {
     if (!this._supportsRollback) {
-      this.logger?.error(
+      this.logger.error(
         "Unable to abort transaction since provider doesn't support rollback"
       );
       throw new Error(

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -36,6 +36,7 @@ import {
   QuerySortOrder,
   ItemType,
   KeyPathType,
+  IObjectStoreProviderLogger,
   KeyType,
 } from "./ObjectStoreProvider";
 import {
@@ -45,7 +46,6 @@ import {
   getSerializedKeyForKeypath,
   getValueForSingleKeypath,
   MAX_COUNT,
-  Logger,
   trimArray,
 } from "./ObjectStoreProviderUtils";
 import {
@@ -62,19 +62,18 @@ export interface StoreData {
   mapType?: OrderedMapType;
 }
 
-// Very simple in-memory dbprovider for handling IE inprivate windows (and unit tests, maybe?)
 export class InMemoryProvider extends DbProvider {
   private _stores: Map<string, StoreData> = new Map();
 
   private _lockHelper: TransactionLockHelper | undefined;
   private readonly _mapType?: OrderedMapType;
   private readonly _supportsRollback?: boolean;
-  private logger: Logger;
+  private logger: IObjectStoreProviderLogger;
 
   constructor(
     mapType?: OrderedMapType,
     supportsRollback = false,
-    logger?: Logger
+    logger?: IObjectStoreProviderLogger
   ) {
     super();
     this._mapType = mapType;
@@ -147,7 +146,7 @@ class InMemoryTransaction implements DbTransaction {
     private _transToken: TransactionToken,
     private _writeNeeded: boolean,
     private _supportsRollback: boolean,
-    private logger: Logger
+    private logger: IObjectStoreProviderLogger
   ) {
     // Close the transaction on the next tick.  By definition, anything is completed synchronously here, so after an event tick
     // goes by, there can't have been anything pending.

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -152,7 +152,7 @@ class InMemoryTransaction implements DbTransaction {
     private _transToken: TransactionToken,
     private _writeNeeded: boolean,
     private _supportsRollback: boolean,
-    private logger: Logger
+    private logger: Logger | undefined
   ) {
     // Close the transaction on the next tick.  By definition, anything is completed synchronously here, so after an event tick
     // goes by, there can't have been anything pending.
@@ -181,7 +181,7 @@ class InMemoryTransaction implements DbTransaction {
 
   abort(): void {
     if (!this._supportsRollback) {
-      this.logger.error(
+      this.logger?.error(
         "Unable to abort transaction since provider doesn't support rollback"
       );
       throw new Error(

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -51,6 +51,7 @@ import {
   formListOfKeys,
   getValueForSingleKeypath,
   getSerializedKeyForKeypath,
+  Logger,
 } from "./ObjectStoreProviderUtils";
 import {
   TransactionToken,
@@ -68,12 +69,6 @@ declare global {
     msIndexedDB: IDBFactory;
   }
 }
-
-type Logger = {
-  log(message?: any, ...optionalParams: any[]): void;
-  warn(message?: any, ...optionalParams: any[]): void;
-  error(message?: any, ...optionalParams: any[]): void;
-};
 
 // The DbProvider implementation for IndexedDB.  This one is fairly straightforward since the library's access patterns pretty
 // closely mirror IndexedDB's.  We mostly do a lot of wrapping of the APIs into JQuery promises and have some fancy footwork to

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -40,6 +40,7 @@ import {
   IDBCloseConnectionEventDetails,
   IDBCloseConnectionPayload,
   OnCloseHandler,
+  IObjectStoreProviderLogger,
 } from "./ObjectStoreProvider";
 import { ItemType, KeyPathType, KeyType } from "./ObjectStoreProvider";
 import {
@@ -51,7 +52,6 @@ import {
   formListOfKeys,
   getValueForSingleKeypath,
   getSerializedKeyForKeypath,
-  Logger,
 } from "./ObjectStoreProviderUtils";
 import {
   TransactionToken,
@@ -80,14 +80,14 @@ export class IndexedDbProvider extends DbProvider {
   private _handleOnClose: OnCloseHandler | undefined = undefined;
 
   private _lockHelper: TransactionLockHelper | undefined;
-  private logger: Logger;
+  private logger: IObjectStoreProviderLogger;
 
   // By default, it uses the in-browser indexed db factory, but you can pass in an explicit factory.  Currently only used for unit tests.
   constructor(
     explicitDbFactory?: IDBFactory,
     explicitDbFactorySupportsCompoundKeys?: boolean,
     handleOnClose?: OnCloseHandler,
-    logger?: Logger
+    logger?: IObjectStoreProviderLogger
   ) {
     super();
 
@@ -538,7 +538,7 @@ class IndexedDbTransaction implements DbTransaction {
     private _transToken: TransactionToken,
     private _schema: DbSchema,
     private _fakeComplicatedKeys: boolean,
-    private logger: Logger
+    private logger: IObjectStoreProviderLogger
   ) {
     this._stores = map(this._transToken.storeNames, (storeName) =>
       this._trans.objectStore(storeName)

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -96,11 +96,7 @@ export class IndexedDbProvider extends DbProvider {
   ) {
     super();
 
-    if (!logger) {
-      logger = console;
-    }
-
-    this.logger = logger;
+    this.logger = logger ? logger : console;
 
     if (explicitDbFactory) {
       this._dbFactory = explicitDbFactory;

--- a/src/ObjectStoreProvider.ts
+++ b/src/ObjectStoreProvider.ts
@@ -23,6 +23,12 @@ export enum QuerySortOrder {
   Reverse,
 }
 
+export interface IObjectStoreProviderLogger {
+  log(message?: any, ...optionalParams: any[]): void;
+  warn(message?: any, ...optionalParams: any[]): void;
+  error(message?: any, ...optionalParams: any[]): void;
+}
+
 // Schema type describing an index for a store.
 export interface IndexSchema {
   name: string;

--- a/src/ObjectStoreProviderUtils.ts
+++ b/src/ObjectStoreProviderUtils.ts
@@ -26,12 +26,6 @@ declare global {
   }
 }
 
-export interface Logger {
-  log(message?: any, ...optionalParams: any[]): void;
-  warn(message?: any, ...optionalParams: any[]): void;
-  error(message?: any, ...optionalParams: any[]): void;
-}
-
 // Max array length (uint): 2^32 - 1
 export const MAX_COUNT = 4294967295;
 

--- a/src/ObjectStoreProviderUtils.ts
+++ b/src/ObjectStoreProviderUtils.ts
@@ -32,7 +32,6 @@ export type Logger = {
   error(message?: any, ...optionalParams: any[]): void;
 };
 
-
 // Max array length (uint): 2^32 - 1
 export const MAX_COUNT = 4294967295;
 

--- a/src/ObjectStoreProviderUtils.ts
+++ b/src/ObjectStoreProviderUtils.ts
@@ -26,11 +26,11 @@ declare global {
   }
 }
 
-export type Logger = {
+export interface Logger {
   log(message?: any, ...optionalParams: any[]): void;
   warn(message?: any, ...optionalParams: any[]): void;
   error(message?: any, ...optionalParams: any[]): void;
-};
+}
 
 // Max array length (uint): 2^32 - 1
 export const MAX_COUNT = 4294967295;

--- a/src/ObjectStoreProviderUtils.ts
+++ b/src/ObjectStoreProviderUtils.ts
@@ -26,6 +26,13 @@ declare global {
   }
 }
 
+export type Logger = {
+  log(message?: any, ...optionalParams: any[]): void;
+  warn(message?: any, ...optionalParams: any[]): void;
+  error(message?: any, ...optionalParams: any[]): void;
+};
+
+
 // Max array length (uint): 2^32 - 1
 export const MAX_COUNT = 4294967295;
 


### PR DESCRIPTION
Adds an additional parameter to pass in an arbitrary logger to optionally use instead of browser console, if logger isn't provided it uses the browser console

This is backwards compatible.