### PR TITLE
Remove unnecessary db upgrade log

### DIFF
--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -376,8 +376,6 @@ export class IndexedDbProvider extends DbProvider {
 
           if (needsMigrate) {
             this.logWriter.log(`schema changes require rebuilding indices`);
-          } else {
-            this.logWriter.log(`Creating stores as part of upgrade process`);
           }
         });
 


### PR DESCRIPTION
Removing unnecessary logging that happens on IndexedDbProvider.open. 
We log when we create the store and indices earlier in the code. Then later we log again that stores were created, which is not accurate because it is possible that no stores were created.

Proposing to remove this line because it is noisy as it gets called on every db.open, and we already log when each individual store gets created.