### PR TITLE
Improve InMemoryProvider getRange function from O(N^2) to O(N)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -3,7 +3,11 @@ export {
   breakAndNormalizeSearchPhrase,
   getFullTextIndexWordsForItem,
 } from "./src/FullTextSearchHelpers";
-export { InMemoryProvider, StoreData } from "./src/InMemoryProvider";
+export {
+  InMemoryProvider,
+  StoreData,
+  ILiveConsumerConfigs,
+} from "./src/InMemoryProvider";
 export {
   ItemType,
   KeyComponentType,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.48",
+  "version": "0.7.0",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.6.47",
+  "version": "0.6.48",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -740,7 +740,7 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
       const iterator = reverse
         ? this._indexTree.entriesReversed()
         : this._indexTree.entries();
-      let values = [] as ItemType[];
+      const values = [] as ItemType[];
       for (const entry of iterator) {
         const key = entry.key;
         if (key === undefined) {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -64,12 +64,12 @@ export interface StoreData {
 
 export interface ILiveConsumerConfigs {
   usePushForGetRange: boolean;
-};
+}
 
 export type GetLiveConsumerConfigsFn = () => ILiveConsumerConfigs;
 
 const defaultLiveConsumerConfigs: ILiveConsumerConfigs = {
-  usePushForGetRange: false
+  usePushForGetRange: false,
 };
 
 export class InMemoryProvider extends DbProvider {
@@ -765,7 +765,7 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
       let values = [] as ItemType[];
       const { usePushForGetRange } = this.getLiveConfigs();
       const pushValues = (values: ItemType[], newValues: ItemType[]) => {
-        newValues.forEach(v => values.push(v));
+        newValues.forEach((v) => values.push(v));
         return values;
       };
       const concatValues = (values: ItemType[], newValues: ItemType[]) => {

--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -768,17 +768,16 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
             break;
           }
 
+          const pushToResult = (v: ItemType) => values.push(v);
           if (this.isUniqueIndex()) {
-            values = values.concat(this._indexTree.get(key) as ItemType[]);
+            (this._indexTree.get(key) as ItemType[]).forEach(pushToResult);
           } else {
-            values = values.concat(
-              this._getKeyValues(
-                key,
-                limit - values.length,
-                Math.abs(offset),
-                reverse
-              )
-            );
+            this._getKeyValues(
+              key,
+              limit - values.length,
+              Math.abs(offset),
+              reverse
+            ).forEach(pushToResult);
 
             if (offset < 0) {
               offset = 0;


### PR DESCRIPTION
I noticed that in the getRange function we're doing a O(N^2) operation when constructing the results array. This time complexity arises because of doing a concat of 2 arrays instead of doing push operations on a single array.