### PR TITLE
Fix error: Cannot read properties of undefined (reading 'idxKey')

### DIFF
--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -551,7 +551,10 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
         );
       }
     } else {
-      keys = [getSerializedKeyForKeypath(item, this._keyPath)!!!];
+      const keyFromKeyPath = getSerializedKeyForKeypath(item, this._keyPath);
+      if (keyFromKeyPath) {
+        keys = [keyFromKeyPath];
+      }
     }
     return keys;
   }


### PR DESCRIPTION
We are getting reports of issues with `Cannot read properties of undefined (reading 'idxKey')` error.

<img width="1391" alt="image" src="https://github.com/user-attachments/assets/50f5de5f-4c03-42de-b6ad-3b695364f268" />

This error is coming from `InMemoryIndex.remove()` method: [here](https://github.com/microsoft/ObjectStoreProvider/blob/6b70241f7fffffb55933350046ab338529674fae/src/InMemoryProvider.ts#L616-L649) in `src/InMemoryProvider.ts` file.

Tracing through this, this method is called from `InMemoryStore._removeFromIndices` method, [here](https://github.com/microsoft/ObjectStoreProvider/blob/6b70241f7fffffb55933350046ab338529674fae/src/InMemoryProvider.ts#L486-L514). Before calling `InMemoryIndex.remove()`, there is a call to `InMemoryIndex.internal_getKeysFromItem` method to return a key and this method could return an array with `undefined` value in it and this may cause this error when trying to read `idxKey` from an object that's undefined, see [here](https://github.com/microsoft/ObjectStoreProvider/blob/6b70241f7fffffb55933350046ab338529674fae/src/InMemoryProvider.ts#L554C15-L554C41) and [here](https://github.com/microsoft/ObjectStoreProvider/blob/6b70241f7fffffb55933350046ab338529674fae/src/ObjectStoreProviderUtils.ts#L84)

Fix here is making sure, we always create an array with valid entries.