### PR TITLE
add getAllRecords support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v2
 
       # Sets up Node and an .npmrc file. This is the official Github supported way to set up node.
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "12"
           registry-url: "https://registry.npmjs.org"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
 
       # Sets up Node and an .npmrc file. This is the official Github supported way to set up node.
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: "12"
           registry-url: "https://registry.npmjs.org"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/objectstoreprovider",
-  "version": "0.7.2",
+  "version": "0.8.0",
   "description": "A cross-browser object store library",
   "author": "Mukundan Kavanur Kidambi <mukav@microsoft.com>",
   "scripts": {

--- a/src/types/extended-idb.d.ts
+++ b/src/types/extended-idb.d.ts
@@ -1,0 +1,43 @@
+export {};
+
+export type IDBGetAllRecordsOptions = {
+  // The maximum number of records to retrieve.
+  count: number;
+
+  // The direction of the cursor when retrieving records.
+  // "next" for ascending order, "prev" for descending order.
+  direction: "next" | "prev";
+
+  query: IDBKeyRange | null;
+};
+
+// Response of new getAllRecords method.
+type IDBRecord = {
+  key: any;
+  primaryKey: any;
+  value: any;
+};
+
+// Extending interfaces with new methods, which are not in typeScript library yet.
+// More details can be found in https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/IndexedDbGetAllEntries/explainer.md
+declare global {
+  interface IDBIndex {
+    /**
+     * Retrieves all records in the index.
+     * This is an experimental new API and may not be available in all environments.
+     */
+    getAllRecords?: (
+      options?: IDBGetAllRecordsOptions
+    ) => IDBRequest<IDBRecord[]>;
+  }
+
+  interface IDBObjectStore {
+    /**
+     * Retrieves all records in the index
+     * This is an experimental new API and may not be available in all environments.
+     */
+    getAllRecords?: (
+      options?: IDBGetAllRecordsOptions
+    ) => IDBRequest<IDBRecord[]>;
+  }
+}


### PR DESCRIPTION
extend IDB provider to support new getAllRecords method of Chromium, it provides more effective way to load byRange in backwards direction

more details can be found in this wiki https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/IndexedDbGetAllEntries/explainer.md