### PR TITLE
Fix removeRange in InMemoryProvider

### DIFF
--- a/src/InMemoryProvider.ts
+++ b/src/InMemoryProvider.ts
@@ -920,7 +920,7 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
     const iterator = this._indexTree.entries();
     const keys = [];
     for (const entry of iterator) {
-      const key = entry.key;
+      let key = entry.key;
       if (key === undefined) {
         continue;
       }
@@ -929,9 +929,17 @@ class InMemoryIndex extends DbIndexFTSFromRangeQueries {
         (key > keyLow || (key === keyLow && !lowRangeExclusive)) &&
         (key < keyHigh || (key === keyHigh && !highRangeExclusive))
       ) {
+        if (this._keyPath !== this._primaryKeyPath) {
+          key =
+            getSerializedKeyForKeypath(
+              entry.value?.[0],
+              this._primaryKeyPath
+            ) ?? key;
+        }
         keys.push(key);
       }
     }
+
     return keys;
   }
 

--- a/src/tests/ObjectStoreProvider.spec.ts
+++ b/src/tests/ObjectStoreProvider.spec.ts
@@ -1886,6 +1886,71 @@ describe("ObjectStoreProvider", function () {
             );
         });
 
+        it("Remove range (all removed with index)", (done) => {
+          // Not working with index, need to be fix in the future.
+          if (provName === "indexeddbfakekeys") {
+            done();
+            return;
+          }
+
+          openProvider(
+            provName,
+            {
+              version: 1,
+              stores: [
+                {
+                  name: "test",
+                  primaryKeyPath: "id",
+                  indexes: [
+                    {
+                      name: "index",
+                      keyPath: "a",
+                    },
+                  ],
+                },
+              ],
+            },
+            true
+          )
+            .then((prov) => {
+              return prov
+                .put(
+                  "test",
+                  [1, 2, 3, 4, 5].map((i) => {
+                    return { id: "a" + i, a: "index_value_a_" + i };
+                  })
+                )
+                .then(() => {
+                  return prov.getAll("test", undefined).then((rets) => {
+                    assert(!!rets);
+                    assert.equal(rets.length, 5);
+                    return prov
+                      .removeRange(
+                        "test",
+                        "index",
+                        "index_value_a_1",
+                        "index_value_a_5"
+                      )
+                      .then(() => {
+                        return prov
+                          .getAll("test", undefined)
+                          .then((retVals) => {
+                            const rets = retVals as TestObj[];
+                            assert(!!rets);
+                            assert.equal(rets.length, 0);
+                          });
+                      });
+                  });
+                })
+                .then(() => prov.close())
+                .catch((e) => prov.close().then(() => Promise.reject(e)));
+            })
+            .then(
+              () => done(),
+              (err) => done(err)
+            );
+        });
+
         it("Invalid Key Type", (done) => {
           openProvider(
             provName,


### PR DESCRIPTION
RemoveRange was not working in InMemoryProvider when an index was used.
Because getKeysForRange was returning the index's key and not the primary index's key.