### PR TITLE
Eagerly create multi-entry/fulltext index object stores in transaction constructor

### DIFF
--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -825,7 +825,7 @@ export class IndexedDbTransaction implements DbTransaction {
               errorDetail +
               ", History: " +
               history.join(",")
-          ) 
+          )
         );
       };
 
@@ -878,7 +878,9 @@ export class IndexedDbTransaction implements DbTransaction {
           const indexStoreName = storeSchema.name + "_" + indexSchema.name;
           const indexStore = this._indexStoreMap.get(indexStoreName);
           if (!indexStore) {
-            throw new Error("Index store not found in transaction: " + indexStoreName);
+            throw new Error(
+              "Index store not found in transaction: " + indexStoreName
+            );
           }
           indexStores.push(indexStore);
         }

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -825,7 +825,7 @@ export class IndexedDbTransaction implements DbTransaction {
               errorDetail +
               ", History: " +
               history.join(",")
-          )
+          ) 
         );
       };
 

--- a/src/IndexedDbProvider.ts
+++ b/src/IndexedDbProvider.ts
@@ -746,6 +746,7 @@ export class IndexedDbProvider extends DbProvider {
 // DbTransaction implementation for the IndexedDB DbProvider.
 export class IndexedDbTransaction implements DbTransaction {
   private _stores: IDBObjectStore[];
+  private _indexStoreMap: Map<string, IDBObjectStore>;
 
   constructor(
     private _trans: IDBTransaction,
@@ -759,6 +760,28 @@ export class IndexedDbTransaction implements DbTransaction {
     this._stores = map(this._transToken.storeNames, (storeName) =>
       this._trans.objectStore(storeName)
     );
+
+    // Eagerly capture multi-entry/fullText index object stores while the transaction is still
+    // in "active" state. Deferring this to getStore() risks an InvalidStateError if the event
+    // loop runs between openTransaction() and the first getStore() call, causing the IDB
+    // transaction to auto-commit before the objectStore() call.
+    this._indexStoreMap = new Map<string, IDBObjectStore>();
+    if (_fakeComplicatedKeys) {
+      each(this._transToken.storeNames, (storeName) => {
+        const storeSchema = find(_schema.stores, (s) => s.name === storeName);
+        if (storeSchema?.indexes) {
+          each(storeSchema.indexes, (indexSchema) => {
+            if (indexSchema.multiEntry || indexSchema.fullText) {
+              const indexStoreName = storeSchema.name + "_" + indexSchema.name;
+              this._indexStoreMap.set(
+                indexStoreName,
+                this._trans.objectStore(indexStoreName)
+              );
+            }
+          });
+        }
+      });
+    }
 
     if (lockHelper) {
       // Chromium seems to have a bug in their indexeddb implementation that lets it start a timeout
@@ -847,12 +870,17 @@ export class IndexedDbTransaction implements DbTransaction {
 
     const indexStores: IDBObjectStore[] = [];
     if (this._fakeComplicatedKeys && storeSchema.indexes) {
-      // Pull the alternate multientry stores in as well
+      // Pull the alternate multientry stores in as well, using the map populated eagerly in the
+      // constructor to avoid calling objectStore() after an async yield (which would throw
+      // InvalidStateError if the transaction has already auto-committed).
       each(storeSchema.indexes, (indexSchema) => {
         if (indexSchema.multiEntry || indexSchema.fullText) {
-          indexStores.push(
-            this._trans.objectStore(storeSchema.name + "_" + indexSchema.name)
-          );
+          const indexStoreName = storeSchema.name + "_" + indexSchema.name;
+          const indexStore = this._indexStoreMap.get(indexStoreName);
+          if (!indexStore) {
+            throw new Error("Index store not found in transaction: " + indexStoreName);
+          }
+          indexStores.push(indexStore);
         }
       });
     }


### PR DESCRIPTION
## Problem

`IndexedDbProvider.openTransaction()` creates the IDB transaction inside a `.then()` callback. When `_fakeComplicatedKeys` is `true`, multi-entry and full-text indexes are emulated as separate physical IDB object stores (e.g. `replyChains_byMessageSearchKeys`, `dbVersion_dbName`). These extra stores must be included in the IDB transaction scope — and `openTransaction()` does include them in the `db.transaction()` call — but the constructor of `IndexedDbTransaction` only captures references to the **primary** stores. The index stores are captured lazily, inside `getStore()`.

This creates a timing bug:

```
IndexedDbProvider.openTransaction(["replyChains"], false)
  → lockHelper.openTransaction(...)               // Promise<token>
  → .then(token => {                              // microtask M1
        trans = db.transaction([
            "replyChains",
            "replyChains_byMessageSearchKeys",    // added by openTransaction
        ], "readonly");                           // IDB tx created — "active" in M1
        return new IndexedDbTransaction(trans, ...);
        // constructor: this._stores = [trans.objectStore("replyChains")]  ✓
        //              _indexStoreMap NOT populated                        ✗
    })
  // M1 exits → transaction transitions "active" → "inactive"

DbProvider._getStoreTransaction().then(trans => {  // microtask M2
    trans.getStore("replyChains")
      → this._trans.objectStore("replyChains_byMessageSearchKeys")
      //  ↑ throws InvalidStateError: transaction is no longer "active"
})
```

An IDB transaction is only "active" for the duration of the task or microtask in which it was created (or in which one of its request events fired). By the time `getStore()` is called in M2, the transaction has gone inactive and `objectStore()` throws `InvalidStateError`.

Even without any actual IDB requests being issued, the transaction can auto-commit once it goes inactive and the current event task completes with no pending requests — leaving it in a "done" state that also makes any subsequent `objectStore()` call throw.

## Solution

Eagerly capture multi-entry/full-text index object stores in the `IndexedDbTransaction` constructor, in the same microtask (`M1`) as the `db.transaction()` call — while the transaction is guaranteed to still be "active".

```typescript
// Eagerly populate _indexStoreMap in the constructor alongside _stores,
// so objectStore() is called while the transaction is still "active".
this._indexStoreMap = new Map<string, IDBObjectStore>();
if (_fakeComplicatedKeys) {
    each(this._transToken.storeNames, (storeName) => {
        const storeSchema = find(_schema.stores, (s) => s.name === storeName);
        if (storeSchema?.indexes) {
            each(storeSchema.indexes, (indexSchema) => {
                if (indexSchema.multiEntry || indexSchema.fullText) {
                    const indexStoreName = storeSchema.name + "_" + indexSchema.name;
                    this._indexStoreMap.set(indexStoreName, this._trans.objectStore(indexStoreName));
                }
            });
        }
    });
}
```

`getStore()` is updated to look up from this map rather than calling `this._trans.objectStore()` lazily.
