### PR TITLE
Bump lodash version 4.17.21 -> 4.18.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,12 +26,13 @@
     "registry": "https://registry.npmjs.org"
   },
   "resolutions": {
-    "minimatch": "^3.1.3"
+    "minimatch": "^3.1.3",
+    "lodash": "^4.18.0"
   },
   "dependencies": {
     "@collectable/core": "^5.0.1",
     "@collectable/red-black-tree": "^5.1.1",
-    "lodash": "^4.17.21",
+    "lodash": "^4.18.1",
     "regexp-i18n": "^1.3.2",
     "sorted-btree": "^1.5.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2253,10 +2253,10 @@ lodash.truncate@^4.4.2:
   resolved "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz"
   integrity sha1-WjUNoLERO4N+z//VgSy+WNbq4ZM=
 
-lodash@^4.17.15, lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+lodash@^4.17.15, lodash@^4.17.21, lodash@^4.18.0, lodash@^4.18.1:
+  version "4.18.1"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.18.1.tgz#ff2b66c1f6326d59513de2407bf881439812771c"
+  integrity sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==
 
 log-symbols@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
Updates lodash version to address vulnerability. Setting resolution to 4.18.0 so all packages must update.